### PR TITLE
Changing requires to install_requires, as that's the setuptools argument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
             'Programming Language :: Python',
             'Topic :: Scientific/Engineering :: Bio-Informatics',
              ],
-        requires=['sqlite3', 'pandas', 'appdirs', 'progressbar', 'biopython'],
+        install_requires=['pandas', 'appdirs', 'progressbar', 'biopython'],
         long_description=readme,
         packages=['datacache'],
     )


### PR DESCRIPTION
Also removing sqlite3, as (as far as I understand) it's bundled with Python >= 2.5. https://docs.python.org/2/library/sqlite3.html

If we do want to include it for Python < 2.5, it looks like it should be included as pysqlite. Let me know if you think that should happen. https://github.com/ghaering/pysqlite
