### PR TITLE
Switch from nose to pytest

### DIFF
--- a/test/test_cache_object.py
+++ b/test/test_cache_object.py
@@ -1,7 +1,7 @@
 from os import remove
 from os.path import exists
 from mock import patch
-from nose.tools import eq_
+
 
 from datacache import Cache
 
@@ -26,7 +26,8 @@ def test_cache_fetch_google():
         "Expected local file to be named %s but got %s" % (
             TEST_FILENAME, path)
     assert exists(path), "File not found: %s" % path
-    eq_(path, cache.local_path(TEST_URL, filename=TEST_FILENAME))
+    assert(path == cache.local_path(TEST_URL, filename=TEST_FILENAME))
+
 
 
 @patch('datacache.cache.download._download_and_decompress_if_necessary')

--- a/test/test_database_objects.py
+++ b/test/test_database_objects.py
@@ -6,7 +6,6 @@ import tempfile
 
 import datacache
 
-from nose.tools import eq_
 
 TABLE_NAME = "test"
 INT_COL_NAME = "int_col"
@@ -29,11 +28,12 @@ def make_table_object():
 
 def test_database_table_object():
     table = make_table_object()
-    eq_(table.name, TABLE_NAME)
-    eq_(table.indices, INDICES)
-    eq_(table.nullable, NULLABLE)
-    eq_(table.rows, ROWS)
-    eq_(table.indices, INDICES)
+    assert(table.name == TABLE_NAME)
+    assert(table.indices == INDICES)
+    assert(table.nullable == NULLABLE)
+    assert(table.rows == ROWS)
+    assert(table.indices == INDICES)
+
 
 def test_create_db():
     with tempfile.NamedTemporaryFile(suffix="test.db") as f:
@@ -49,4 +49,4 @@ def test_create_db():
         cursor = db.connection.execute(sql)
         int_result_tuple = cursor.fetchone()
         int_result = int_result_tuple[0]
-        eq_(int_result, 2)
+        assert(int_result == 2)

--- a/test/test_database_types.py
+++ b/test/test_database_types.py
@@ -1,4 +1,3 @@
-from nose.tools import eq_
 import numpy as np
 from datacache.database_types import db_type
 
@@ -7,9 +6,9 @@ def test_db_types():
             int,
             np.int8, np.int16, np.int32, np.int64,
             np.uint8, np.uint16, np.uint32, np.uint64]:
-        eq_(db_type(int_type), "INT")
+        assert(db_type(int_type) == "INT")
 
     for float_type in [float, np.float32, np.float64]:
-        eq_(db_type(float), "FLOAT")
+        assert(db_type(float) == "FLOAT")
 
-    eq_(db_type(str), "TEXT")
+    assert(db_type(str) == "TEXT")


### PR DESCRIPTION
http://nose.readthedocs.io/en/latest/index.html

Nose is deprecated, therefore we should probably move to other alternatives. This PR removes references where nose was used.