### PR TITLE
Fix #45: allow cached SQLite connection to be reused across threads

### DIFF
--- a/datacache/database.py
+++ b/datacache/database.py
@@ -35,7 +35,13 @@ class Database(object):
     """
     def __init__(self, path):
         self.path = path
-        self.connection = sqlite3.connect(path)
+        # check_same_thread=False allows a cached database connection to be
+        # reused across threads, which is needed by long-running / interactive
+        # consumers (e.g. pyensembl) that may issue queries from different
+        # threads than the one which opened the connection. datacache databases
+        # are written once and read-only thereafter, so cross-thread reuse is
+        # safe here. See https://github.com/openvax/datacache/issues/45
+        self.connection = sqlite3.connect(path, check_same_thread=False)
 
     def _commit(self):
         self.connection.commit()

--- a/tests/test_database_objects.py
+++ b/tests/test_database_objects.py
@@ -3,6 +3,7 @@ Test that datacache constructs databases correctly
 (separately from downloading/caching them)
 """
 import tempfile
+import threading
 
 import datacache
 
@@ -51,3 +52,24 @@ def test_create_db():
         int_result_tuple = cursor.fetchone()
         int_result = int_result_tuple[0]
         eq_(int_result, 2)
+
+def test_query_db_from_another_thread():
+    # regression test for https://github.com/openvax/datacache/issues/45:
+    # a connection opened in one thread must remain usable from another thread.
+    with tempfile.NamedTemporaryFile(suffix="test.db") as f:
+        db = datacache.database.Database(f.name)
+        table = make_table_object()
+        db.create(tables=[table], version=VERSION)
+
+        results = {}
+
+        def query_in_thread():
+            cursor = db.connection.execute(
+                "SELECT %s FROM %s WHERE %s = '%s'" % (
+                    INT_COL_NAME, TABLE_NAME, STR_COL_NAME, "light"))
+            results["value"] = cursor.fetchone()[0]
+
+        thread = threading.Thread(target=query_in_thread)
+        thread.start()
+        thread.join()
+        eq_(results["value"], 2)


### PR DESCRIPTION
## Problem

Closes #45.

Interactive / long-running consumers of datacache (notably **pyensembl**) open a database connection once and then issue queries over a long period. When a query lands on a different thread than the one that opened the connection, sqlite3 raises:

> SQLite objects created in a thread can only be used in that same thread.

## Fix

Open the connection with `check_same_thread=False` in `datacache/database.py`. datacache databases are written once (during `create()`) and read-only thereafter, so allowing cross-thread reuse is safe — there are no concurrent writers to corrupt.

Added a regression test (`test_query_db_from_another_thread`) that creates a database and successfully queries the connection from a second thread.

## Notes

This matches the fix proposed by the reporter in the issue.

https://claude.ai/code/session_011bzfZPTzWnhAMVD7msyMg1