### PR TITLE
Fix #40: replace runtime asserts with explicit exceptions

### DIFF
--- a/datacache/cache.py
+++ b/datacache/cache.py
@@ -20,7 +20,8 @@ from .database_helpers import db_from_dataframe
 
 class Cache(object):
     def __init__(self, subdir="datacache"):
-        assert subdir
+        if not subdir:
+            raise ValueError("Cache subdir must be a non-empty string")
         self.subdir = subdir
         self.cache_directory_path = common.get_data_dir(subdir)
 

--- a/datacache/common.py
+++ b/datacache/common.py
@@ -59,7 +59,8 @@ def build_local_filename(download_url=None, filename=None, decompress=False):
     an optional desired filename, and whether a compression suffix needs
     to be removed
     """
-    assert download_url or filename, "Either filename or URL must be specified"
+    if not (download_url or filename):
+        raise ValueError("Either filename or URL must be specified")
 
     # if no filename provided, use the original filename on the server
     if not filename:

--- a/datacache/database_table.py
+++ b/datacache/database_table.py
@@ -67,9 +67,10 @@ class DatabaseTable(object):
     def from_fasta_dict(cls, name, fasta_dict, key_column, value_column):
         key_list = list(fasta_dict.keys())
         key_set = set(key_list)
-        assert len(key_set) == len(key_list), \
-            "FASTA file from contains %d non-unique sequence identifiers" % \
-            (len(key_list) - len(key_set))
+        if len(key_set) != len(key_list):
+            raise ValueError(
+                "FASTA file from contains %d non-unique sequence identifiers" %
+                (len(key_list) - len(key_set)))
         column_types = [(key_column, "TEXT"), (value_column, "TEXT")]
 
         def make_rows():

--- a/datacache/download.py
+++ b/datacache/download.py
@@ -109,7 +109,8 @@ def _download_and_decompress_if_necessary(
         logger.info("Decompressing zip into %s...", filename)
         with zipfile.ZipFile(tmp_path) as z:
             names = z.namelist()
-            assert len(names) > 0, "Empty zip archive"
+            if len(names) == 0:
+                raise ValueError("Empty zip archive")
             if filename in names:
                 chosen_filename = filename
             else:
@@ -230,7 +231,10 @@ def fetch_and_transform(
     else:
         logger.info("Cached data file: %s", transformed_path)
         result = loader(transformed_path)
-    assert os.path.exists(transformed_path)
+    if not os.path.exists(transformed_path):
+        raise RuntimeError(
+            "Expected transformed file %s to exist after fetch_and_transform" % (
+                transformed_path,))
     return result
 
 


### PR DESCRIPTION
## Problem

Closes #40.

`assert` statements are removed when Python is run in optimized mode (`python -O` / `PYTHONOPTIMIZE`), so they must not be used to enforce validation that needs to hold at runtime. datacache used asserts for input validation and a postcondition check in five places.

## Fix

Replace the runtime asserts with explicit `if/raise`:

| Location | Was | Now |
|---|---|---|
| `cache.py` | `assert subdir` | `ValueError` on empty subdir |
| `common.py` | `assert download_url or filename` | `ValueError` |
| `database_table.py` | `assert` unique FASTA ids | `ValueError` |
| `download.py` | `assert len(names) > 0` (zip) | `ValueError("Empty zip archive")` |
| `download.py` | `assert os.path.exists(...)` | `RuntimeError` (violated postcondition) |

`git grep assert datacache/*.py` now returns nothing. Lint + non-network tests pass.

https://claude.ai/code/session_011bzfZPTzWnhAMVD7msyMg1