### PR TITLE
Fix stale RELEASING.md (deploy.sh, not setup.py sdist upload)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,14 @@
 # Releasing Datacache
 
-This document explains what do once your [Pull Request](https://www.atlassian.com/git/tutorials/making-a-pull-request/) has been reviewed and all final changes applied. Now you're ready merge your branch into master and release it to the world:
+This document explains what to do once your [Pull Request](https://www.atlassian.com/git/tutorials/making-a-pull-request/) has been reviewed and all final changes applied. Now you're ready to merge your branch into master and release it to the world:
 
-0. Make sure that you have `pandoc` and `pypandoc` installed: this is needed for readme markdown on PyPI. (See [here](http://pandoc.org/installing.html) and [here](https://pypi.python.org/pypi/pypandoc), respectively, for instructions.)
-1. Bump the [version](http://semver.org/) in `setup.py`, as part of the PR you want to release.
+1. Bump the [version](http://semver.org/) in `datacache/version.py`, as part of the PR you want to release.
 2. Merge your branch into master.
-3. Run `python setup.py sdist upload`, which pushes the newest release to PyPI.
+3. From a clean `master`, run `./deploy.sh`. It lint-checks, runs the tests, builds the
+   `sdist`/`wheel` with [`build`](https://pypi.org/project/build/), and uploads them to
+   PyPI with [`twine`](https://pypi.org/project/twine/). You'll need PyPI upload
+   credentials configured (e.g. in `~/.pypirc` or via `TWINE_USERNAME`/`TWINE_PASSWORD`).
+
+> **Note:** `python setup.py sdist upload` is deprecated and no longer works — PyPI
+> rejects uploads from `setup.py`, and the project has moved to `pyproject.toml` (there
+> is no `setup.py`). Always release via `./deploy.sh` (i.e. `build` + `twine`).


### PR DESCRIPTION
RELEASING.md was stale on every step:

- referenced `setup.py` for the version bump — but the project moved to
  `pyproject.toml`; the version lives in `datacache/version.py`,
- a `pandoc`/`pypandoc` step for "readme markdown on PyPI" that's no longer needed
  (PyPI renders the markdown `README.md` directly),
- `python setup.py sdist upload` to publish — deprecated and rejected by PyPI.

Updated to the real process backed by the repo's `deploy.sh`:

1. bump `datacache/version.py` in the release PR,
2. merge to master,
3. run `./deploy.sh` from clean master (lint + test + `build` + `twine upload`).

Doc-only; no version bump (not a release).